### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:25.3.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:25.3.0'
 }


### PR DESCRIPTION
The compile configuration is now deprecated and should be replaced by implementation or api.